### PR TITLE
Missing permissions for Android 9 or higher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
The app crash when start playing on device with Android 9 or higher:

Just need add `<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />` to Android Manifest